### PR TITLE
20181102 divided council email list into districts to be consistent with contact council page

### DIFF
--- a/lists/email-councils/index.php
+++ b/lists/email-councils/index.php
@@ -45,12 +45,27 @@ $description = "Find the email address of any/all town or county councillor in I
     foreach ($items as $item) {
 
       $email_addresses = $item['emails'];
-      print $item['council_name'];
-      print '<ul>';
-      foreach ($email_addresses as $email_address) {
-        print '<li>' . $email_address . '</li>';
-      }
-      print '</ul>';
+	  $mundistricts = $item['district'];
+	  
+	  if ($mundistricts === "") {
+		  print $item['council_name'];
+		  print '<ul>';
+		  foreach ($email_addresses as $email_address) {
+			print '<li>' . $email_address . '</li>';
+		  }
+		  print '</ul>';
+	  }else{
+		  print '<h3>' . $item['council_name'] . '</h3><br>';
+		  foreach ($mundistricts as $district => $emailAddr) {
+			print $district;
+			print '<ul>';
+			for ($i=0;$i<count($emailAddr);$i++){
+				print '<li>' . $emailAddr[$i] . '</li>';
+			}
+			print '</ul>';
+		  }
+		  print '</ul>';	  
+	  }
     }
     ?>
   </ul>


### PR DESCRIPTION
Hi Mark,

This change divides the councillor email list into municipal districts in the same way the councillor contact page was divided previously. This would keep the two pages consistent. 

You can see a demo here: http://contact.heylinprojects.com/lists/email-councils/

Peter 